### PR TITLE
Proper support for Polygons and MultiPolygons

### DIFF
--- a/valhalla/gui/ValhallaDialog.py
+++ b/valhalla/gui/ValhallaDialog.py
@@ -343,7 +343,6 @@ class ValhallaDialogMain:
                             layer_out.dataProvider().addFeature(feat)
 
                     layer_out.updateExtents()
-                    # isochrones.stylePoly(layer_out, metric)
                     self.project.addMapLayer(layer_out)
 
                 if not no_points:

--- a/valhalla/gui/isochrones_gui.py
+++ b/valhalla/gui/isochrones_gui.py
@@ -72,9 +72,9 @@ class Isochrones:
             'id': 1,
         }
 
-        if denoise:
+        if denoise is not None:
             params['denoise'] = denoise
-        if generalize:
+        if generalize is not None:
             params['generalize'] = generalize
 
         # Get Advanced parameters


### PR DESCRIPTION
With https://github.com/valhalla/valhalla/pull/4575 merged, this makes the plugin compatible with that latest update to the isochrone contour generation. Should be largely backwards compatible to older versions of Valhalla, I've found out a lot of renderers don't really care for correct ring grouping anyways, which is the only thing that might break (before, the plugin would just ignore any polygon rings other than the first one). I'd say let's wait and see if someone complains :)